### PR TITLE
Fixes minor formatting issues in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ log(format(new Date(), 'timezone', 'America/New_York'))
 // 4 April 2015 15:42
 // Today at 15:42
 // a few seconds ago
-// 2015-04-04T15:42:48.4848Z
-// 20150404T034248Z
+// 2015-04-04T15:42:48.123Z
+// 20150404T154248Z
 // Saturday 4 April 2015 10:42 EDT
 ```
 

--- a/config.json
+++ b/config.json
@@ -20,7 +20,7 @@
   "timezone": "Europe/London",
   "formats": {
     "timezone": "LLLL z",
-    "iso": "YYYY-MM-DDTHH:mm:ss.sss[Z]",
-    "isoFileSystem": "YYYYMMDDThhmmss[Z]"
+    "iso": "YYYY-MM-DDTHH:mm:ss.SSS[Z]",
+    "isoFileSystem": "YYYYMMDDTHHmmss[Z]"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,7 +31,7 @@ describe('cf-formatter', function () {
 
   it('should format using custom formats', function () {
      assert.equal(formatter(config)('2001-01-01T00:00:00Z', 'iso'), '2001-01-01T00:00:00.000Z')
-     assert.equal(formatter(config)('2001-01-01T00:00:00Z', 'isoFileSystem'), '20010101T120000Z')
+     assert.equal(formatter(config)('2001-01-01T00:00:00Z', 'isoFileSystem'), '20010101T000000Z')
   })
 
   it('should format using ‘from’ style', function () {


### PR DESCRIPTION
`sss` outputs duplications of seconds – should be `SSS` to output intended fractions of seconds.
`hh` outputs in 12-hour format – should be `HH` to output in 24 hour format.
